### PR TITLE
Set empty Expect: header during all POSTs and PUTs to avoid 100-continue

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -91,6 +91,11 @@ bool Client::Implementation::performRequestOnCurrentHost(Client::HTTPMethod meth
     if (!body.empty()) {
         header["Content-Type"] = "application/json; charset=utf-8";
     }
+    switch (method) {
+        case Client::HTTPMethod::POST:
+        case Client::HTTPMethod::PUT:
+             header["Expect"] = "";
+    }
     session.SetHeader(header);
     session.SetBody(cpr::Body(body));
 


### PR DESCRIPTION
curl inserts Expect: 100-continue in POSTs and PUTs with huge payload. This is not handled well in ec, but one may avoid problem setting empty Expect: header.

compile-tested only